### PR TITLE
Run tests with variants

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,8 @@ aliases:
     command: |
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       conda create -y -n test_genutil --use-local $CHANNELS "$CONDA_PY_VER" $PKG_NAME $PKGS $COVERAGE_PKGS
+       echo "conda create -y -n test_genutil --use-local $CHANNELS \"$CONDA_PY_VER\" $PKG_NAME $PKGS $COVERAGE_PKGS \"$LIBNETCDF\""
+       conda create -y -n test_genutil --use-local $CHANNELS "$CONDA_PY_VER" $PKG_NAME $PKGS $COVERAGE_PKGS "$LIBNETCDF"
        conda activate test_genutil
        conda list
 
@@ -51,14 +52,11 @@ aliases:
   - &conda_upload
     name: conda_upload
     command: |
-       if [[ $CIRCLE_BRANCH != "master" ]]; then
-          exit 0
-       fi
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
        UPLOAD_OPTIONS="-t $CONDA_UPLOAD_TOKEN upload -u $USER -l $LABEL"
-       anaconda $UPLOAD_OPTIONS linux_build/miniconda/conda-bld/linux-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
-       anaconda $UPLOAD_OPTIONS macos_build/miniconda/conda-bld/osx-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
+       anaconda $UPLOAD_OPTIONS linux_build_py*/miniconda/conda-bld/linux-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
+       anaconda $UPLOAD_OPTIONS macos_build_py*/miniconda/conda-bld/osx-64/$PKG_NAME-$VERSION.`date +%Y*`0.tar.bz2 --force
 
   - &run_coveralls
     name: run_coveralls
@@ -103,164 +101,366 @@ jobs:
               paths:
                  - linux_build
 
+   #
+   # build
+   #
    macos_genutil_py36:
       macos:
          xcode: "11.4.0"
       environment:
-         WORKDIR: /Users/distiller/project/macos_build
+         WORKDIR: /Users/distiller/project/macos_build_py36
          PKG_NAME: "genutil"
          REPO_NAME: "genutil"
-         ENV_NAME: "test_genutil"
-         CONDA_PY_VER: "python>=3.6,<3.7"
          BUILD_VARIANT_VER: "3.6"
+         LAST_STABLE: "8.2"
       steps:
          - checkout
-         - attach_workspace:
-              at: .
+         - run: *setup_miniconda
+         - run: *conda_rerender
          - run: *conda_build
-         - run: *setup_run_tests
-         - run: *run_tests
-         - store_artifacts:
-              path: tests_html
-              destination: tests_html
          - persist_to_workspace:
               root: .
               paths:
-                 - macos_build/miniconda/conda-bld/osx-64/genutil*tar.bz2
+                 - macos_build_py36
 
    macos_genutil_py37:
       macos:
          xcode: "11.4.0"
       environment:
-         WORKDIR: /Users/distiller/project/macos_build
+         WORKDIR: /Users/distiller/project/macos_build_py37
          PKG_NAME: "genutil"
          REPO_NAME: "genutil"
-         ENV_NAME: "test_genutil"
-         CONDA_PY_VER: "python>=3.7,<3.8"
          BUILD_VARIANT_VER: "3.7"
+         LAST_STABLE: "8.2"
       steps:
          - checkout
-         - attach_workspace:
-              at: .
+         - run: *setup_miniconda
+         - run: *conda_rerender
          - run: *conda_build
-         - run: *setup_run_tests
-         - run: *run_tests
-         - store_artifacts:
-              path: tests_html
-              destination: tests_html
          - persist_to_workspace:
               root: .
               paths:
-                 - macos_build/miniconda/conda-bld/osx-64/genutil*tar.bz2
+                 - macos_build_py37
 
    macos_genutil_py38:
       macos:
          xcode: "11.4.0"
       environment:
-         WORKDIR: /Users/distiller/project/macos_build
+         WORKDIR: /Users/distiller/project/macos_build_py38
          PKG_NAME: "genutil"
          REPO_NAME: "genutil"
-         ENV_NAME: "test_genutil"
-         CONDA_PY_VER: "python>=3.8,<3.9"
          BUILD_VARIANT_VER: "3.8"
+         LAST_STABLE: "8.2"
       steps:
          - checkout
-         - attach_workspace:
-              at: .
+         - run: *setup_miniconda
+         - run: *conda_rerender
          - run: *conda_build
-         - run: *setup_run_tests
-         - run: *run_tests
-         - store_artifacts:
-              path: tests_html
-              destination: tests_html
          - persist_to_workspace:
               root: .
               paths:
-                 - macos_build/miniconda/conda-bld/osx-64/genutil*tar.bz2
+                 - macos_build_py38
 
    linux_genutil_py36:
       machine:
          image: circleci/classic:latest
       environment:
-         WORKDIR: /home/circleci/project/linux_build
+         WORKDIR: /home/circleci/project/linux_build_py36
          PKG_NAME: "genutil"
          REPO_NAME: "genutil"
-         ENV_NAME: "test_genutil"
-         CONDA_PY_VER: "python>=3.6,<3.7"
          BUILD_VARIANT_VER: "3.6"
+         LAST_STABLE: "8.2"
       steps:
          - checkout
-         - attach_workspace:
-              at: .
+         - run: *setup_miniconda
+         - run: *conda_rerender
          - run: *conda_build
-         - run: *setup_run_tests
-         - run: *run_tests
-         - store_artifacts:
-              path: tests_html
-              destination: tests_html
          - persist_to_workspace:
               root: .
               paths:
-                 - linux_build/miniconda/conda-bld/linux-64/genutil*tar.bz2
+                 - linux_build_py36
 
    linux_genutil_py37:
       machine:
          image: circleci/classic:latest
       environment:
-         WORKDIR: /home/circleci/project/linux_build
+         WORKDIR: /home/circleci/project/linux_build_py37
          PKG_NAME: "genutil"
          REPO_NAME: "genutil"
-         ENV_NAME: "test_genutil"
-         CONDA_PY_VER: "python>=3.7,<3.8"
          BUILD_VARIANT_VER: "3.7"
-         COVERAGE: "-c tests/coverage.json --coverage-from-egg"
-         COVERAGE_PKGS: "coverage coveralls"
+         LAST_STABLE: "8.2"
+      steps:
+         - checkout
+         - run: *setup_miniconda
+         - run: *conda_rerender
+         - run: *conda_build
+         - persist_to_workspace:
+              root: .
+              paths:
+                 - linux_build_py37
+
+   linux_genutil_py38:
+      machine:
+         image: circleci/classic:latest
+      environment:
+         WORKDIR: /home/circleci/project/linux_build_py38
+         PKG_NAME: "genutil"
+         REPO_NAME: "genutil"
+         BUILD_VARIANT_VER: "3.8"
+         LAST_STABLE: "8.2"
+      steps:
+         - checkout
+         - run: *setup_miniconda
+         - run: *conda_rerender
+         - run: *conda_build
+         - persist_to_workspace:
+              root: .
+              paths:
+                 - linux_build_py38
+
+
+   #
+   # run tests with libnetcdf nompi
+   #
+   macos_genutil_nompi_py36:
+      macos:
+         xcode: "11.4.0"
+      environment:
+         WORKDIR: /Users/distiller/project/macos_build_py36
+         PKG_NAME: "genutil"
+         ENV_NAME: "test_genutil"
+         CONDA_PY_VER: "python>=3.6,<3.7"
+         LIBNETCDF: "libnetcdf=*=nompi_*"
       steps:
          - checkout
          - attach_workspace:
               at: .
-         - run: *conda_build
+         - run: *setup_run_tests
+         - run: *run_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+
+   macos_genutil_nompi_py37:
+      macos:
+         xcode: "11.4.0"
+      environment:
+         WORKDIR: /Users/distiller/project/macos_build_py37
+         PKG_NAME: "genutil"
+         ENV_NAME: "test_genutil"
+         CONDA_PY_VER: "python>=3.7,<3.8"
+         LIBNETCDF: "libnetcdf=*=nompi_*"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_run_tests
+         - run: *run_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+
+   macos_genutil_nompi_py38:
+      macos:
+         xcode: "11.4.0"
+      environment:
+         WORKDIR: /Users/distiller/project/macos_build_py38
+         PKG_NAME: "genutil"
+         ENV_NAME: "test_genutil"
+         CONDA_PY_VER: "python>=3.8,<3.9"
+         LIBNETCDF: "libnetcdf=*=nompi_*"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_run_tests
+         - run: *run_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+
+   linux_genutil_nompi_py36:
+      machine:
+         image: circleci/classic:latest
+      environment:
+         WORKDIR: /home/circleci/project/linux_build_py36
+         PKG_NAME: "genutil"
+         ENV_NAME: "test_genutil"
+         CONDA_PY_VER: "python>=3.6,<3.7"
+         LIBNETCDF: "libnetcdf=*=nompi_*"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_run_tests
+         - run: *run_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+
+   linux_genutil_nompi_py37:
+      machine:
+         image: circleci/classic:latest
+      environment:
+         WORKDIR: /home/circleci/project/linux_build_py37
+         PKG_NAME: "genutil"
+         ENV_NAME: "test_genutil"
+         CONDA_PY_VER: "python>=3.7,<3.8"
+         COVERAGE: "-c tests/coverage.json --coverage-from-egg"
+         COVERAGE_PKGS: "coverage coveralls"
+         LIBNETCDF: "libnetcdf=*=nompi_*"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
          - run: *setup_run_tests
          - run: *run_tests
          - run: *run_coveralls
          - store_artifacts:
               path: tests_html
               destination: tests_html
-         - persist_to_workspace:
-              root: .
-              paths:
-                 - linux_build/miniconda/conda-bld/linux-64/genutil*tar.bz2
 
-   linux_genutil_py38:
+   linux_genutil_nompi_py38:
       machine:
          image: circleci/classic:latest
       environment:
-         WORKDIR: /home/circleci/project/linux_build
+         WORKDIR: /home/circleci/project/linux_build_py38
          PKG_NAME: "genutil"
-         REPO_NAME: "genutil"
          ENV_NAME: "test_genutil"
          CONDA_PY_VER: "python>=3.8,<3.9"
-         BUILD_VARIANT_VER: "3.8"
+         LIBNETCDF: "libnetcdf=*=nompi_*"
       steps:
          - checkout
          - attach_workspace:
               at: .
-         - run: *conda_build
          - run: *setup_run_tests
          - run: *run_tests
          - store_artifacts:
               path: tests_html
               destination: tests_html
-         - persist_to_workspace:
-              root: .
-              paths:
-                 - linux_build/miniconda/conda-bld/linux-64/genutil*tar.bz2
+
+   #
+   # run tests with libnetcdf mpich
+   #
+   macos_genutil_mpich_py36:
+      macos:
+         xcode: "11.4.0"
+      environment:
+         WORKDIR: /Users/distiller/project/macos_build_py36
+         PKG_NAME: "genutil"
+         ENV_NAME: "test_genutil"
+         CONDA_PY_VER: "python>=3.6,<3.7"
+         LIBNETCDF: "libnetcdf=*=mpi_mpich_*"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_run_tests
+         - run: *run_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+
+   macos_genutil_mpich_py37:
+      macos:
+         xcode: "11.4.0"
+      environment:
+         WORKDIR: /Users/distiller/project/macos_build_py37
+         PKG_NAME: "genutil"
+         ENV_NAME: "test_genutil"
+         CONDA_PY_VER: "python>=3.7,<3.8"
+         LIBNETCDF: "libnetcdf=*=mpi_mpich_*"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_run_tests
+         - run: *run_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+
+   macos_genutil_mpich_py38:
+      macos:
+         xcode: "11.4.0"
+      environment:
+         WORKDIR: /Users/distiller/project/macos_build_py38
+         PKG_NAME: "genutil"
+         ENV_NAME: "test_genutil"
+         CONDA_PY_VER: "python>=3.8,<3.9"
+         LIBNETCDF: "libnetcdf=*=mpi_mpich_*"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_run_tests
+         - run: *run_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+
+   linux_genutil_mpich_py36:
+      machine:
+         image: circleci/classic:latest
+      environment:
+         WORKDIR: /home/circleci/project/linux_build_py36
+         PKG_NAME: "genutil"
+         ENV_NAME: "test_genutil"
+         CONDA_PY_VER: "python>=3.6,<3.7"
+         LIBNETCDF: "libnetcdf=*=mpi_mpich_*"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_run_tests
+         - run: *run_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+
+   linux_genutil_mpich_py37:
+      machine:
+         image: circleci/classic:latest
+      environment:
+         WORKDIR: /home/circleci/project/linux_build_py37
+         PKG_NAME: "genutil"
+         ENV_NAME: "test_genutil"
+         CONDA_PY_VER: "python>=3.7,<3.8"
+         LIBNETCDF: "libnetcdf=*=mpi_mpich_*"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_run_tests
+         - run: *run_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
+
+   linux_genutil_mpich_py38:
+      machine:
+         image: circleci/classic:latest
+      environment:
+         WORKDIR: /home/circleci/project/linux_build_py38
+         PKG_NAME: "genutil"
+         ENV_NAME: "test_genutil"
+         CONDA_PY_VER: "python>=3.8,<3.9"
+         LIBNETCDF: "libnetcdf=*=mpi_mpich_*"
+      steps:
+         - checkout
+         - attach_workspace:
+              at: .
+         - run: *setup_run_tests
+         - run: *run_tests
+         - store_artifacts:
+              path: tests_html
+              destination: tests_html
 
    upload:
       machine:
          image: circleci/classic:latest
       environment:
-         WORKDIR: /home/circleci/project/linux_build
+         WORKDIR: /home/circleci/project/linux_build_py36
          PKG_NAME: "genutil"
          VERSION: "8.2"
          USER: "cdat"
@@ -269,37 +469,73 @@ jobs:
          - attach_workspace:
               at: .
          - run: pwd
+         - run: ls -l
          - run: *conda_upload
 
 workflows:
    version: 2
    genutil:
       jobs:
-         - macos_setup
-         - linux_setup
-         - macos_genutil_py36:
-              requires:
-                 - macos_setup
-         - macos_genutil_py37:
-              requires:
-                 - macos_setup
-         - macos_genutil_py38:
-              requires:
-                 - macos_setup
-         - linux_genutil_py36:
-              requires:
-                 - linux_setup
-         - linux_genutil_py37:
-              requires:
-                 - linux_setup
-         - linux_genutil_py38:
-              requires:
-                 - linux_setup
-         - upload:
+         - macos_genutil_py36
+         - macos_genutil_py37
+         - macos_genutil_py38
+         - linux_genutil_py36
+         - linux_genutil_py37
+         - linux_genutil_py38
+
+         - macos_genutil_mpich_py36:
               requires:
                  - macos_genutil_py36
+         - macos_genutil_mpich_py37:
+              requires:
                  - macos_genutil_py37
+         - macos_genutil_mpich_py38:
+              requires:
                  - macos_genutil_py38
+         - linux_genutil_mpich_py36:
+              requires:
                  - linux_genutil_py36
+         - linux_genutil_mpich_py37:
+              requires:
                  - linux_genutil_py37
+         - linux_genutil_mpich_py38:
+              requires:
                  - linux_genutil_py38
+
+         - macos_genutil_nompi_py36:
+              requires:
+                 - macos_genutil_py36
+         - macos_genutil_nompi_py37:
+              requires:
+                 - macos_genutil_py37
+         - macos_genutil_nompi_py38:
+              requires:
+                 - macos_genutil_py38
+         - linux_genutil_nompi_py36:
+              requires:
+                 - linux_genutil_py36
+         - linux_genutil_nompi_py37:
+              requires:
+                 - linux_genutil_py37
+         - linux_genutil_nompi_py38:
+              requires:
+                 - linux_genutil_py38
+
+         - upload:
+              requires:
+                 - macos_genutil_nompi_py36
+                 - macos_genutil_nompi_py37
+                 - macos_genutil_nompi_py38
+                 - linux_genutil_nompi_py36
+                 - linux_genutil_nompi_py37
+                 - linux_genutil_nompi_py38
+
+                 - macos_genutil_mpich_py36
+                 - macos_genutil_mpich_py37
+                 - macos_genutil_mpich_py38
+                 - linux_genutil_mpich_py36
+                 - linux_genutil_mpich_py37
+                 - linux_genutil_mpich_py38
+              filters:
+                 branches:
+                    only: master

--- a/Lib/colors.py
+++ b/Lib/colors.py
@@ -685,13 +685,13 @@ def str2rgb(col):
         f = open('/usr/X11R6/lib/X11/rgb.txt', 'r')
         ln = f.readlines()
         f.close()
-        for l in ln[1:]:
-            c = l.split()[3:]
+        for line in ln[1:]:
+            c = line.split()[3:]
             c = " ".join(c)
             c = c.lower()
             c = c.replace(' ', '')
             if c == col:
-                ret = l.split()[:3]
+                ret = line.split()[:3]
         if len(ret) != 3:
             ret = [None, None, None]
         for i in range(3):
@@ -735,8 +735,8 @@ def rgb2str(r, g=None, b=None):
         f = open('/usr/X11R6/lib/X11/rgb.txt', 'r')
         ln = f.readlines()
         f.close()
-        for l in ln[1:]:
-            sp = l.split()
+        for line in ln[1:]:
+            sp = line.split()
             r2, g2, b2 = float(sp[0]), float(sp[1]), float(sp[2])
             rms = (r2 - r)**2. + (b2 - b)**2. + (g2 - g)**2.
             if rms < rmsmin:

--- a/Lib/selval.py
+++ b/Lib/selval.py
@@ -67,13 +67,13 @@ class PickComponent(SelectorComponent):
                         or isinstance(specs[0], type(cdtime.reltime(0, 'days since 1999')))\
                         or isinstance(specs[0], type('')):
                     list2 = []
-                    for l in specs:
-                        if not isinstance(l, type('')):
-                            list2.append(l.torel('days since 1900').value)
+                    for el in specs:
+                        if not isinstance(el, type('')):
+                            list2.append(el.torel('days since 1900').value)
                         else:
                             list2.append(
                                 cdtime.s2r(
-                                    l, 'days since 1900').value)
+                                    el, 'days since 1900').value)
                     min = minimum(list2)
                     max = maximum(list2)
                     specification[i] = cdtime.reltime(
@@ -121,13 +121,13 @@ class PickComponent(SelectorComponent):
                     if isinstance(specs[0], type(cdtime.comptime(1999))) or isinstance(
                             specs[0], type(cdtime.reltime(0, 'days since 1999'))) or isinstance(specs[0], type('')):
                         list2 = []
-                        for l in specs:
-                            if not isinstance(l, type('')):
-                                list2.append(l.torel('days since 1900').value)
+                        for el in specs:
+                            if not isinstance(el, type('')):
+                                list2.append(el.torel('days since 1900').value)
                             else:
                                 list2.append(
                                     cdtime.s2r(
-                                        l, 'days since 1900').value)
+                                        el, 'days since 1900').value)
                         min = minimum(list2)
                         max = maximum(list2)
                         specification[axis] = cdtime.reltime(
@@ -158,9 +158,9 @@ class PickComponent(SelectorComponent):
                 a = None
                 sh = list(fetched.shape)
                 sh[i] = 1
-                for l in self.aux[i]:
+                for el in self.aux[i]:
                     try:
-                        tmp = fetched(**{faxes[i].id: (l, l)})
+                        tmp = fetched(**{faxes[i].id: (el, el)})
                         ax = tmp.getAxis(i)
                         # print ax
                         newaxvals.append(ax[0])
@@ -172,21 +172,21 @@ class PickComponent(SelectorComponent):
                         if self.match == 1:
                             raise Exception(
                                 'Error axis value :' +
-                                str(l) +
+                                str(el) +
                                 ' was requested but is not present in slab\n(more missing might exists)')
                         elif self.match == 0:
                             tmp = MV2.ones(sh, typecode=MV2.float)
                             tmp = MV2.masked_equal(tmp, 1)
-                            if isinstance(l, type(cdtime.comptime(1999))) or isinstance(
-                                    l, type(cdtime.reltime(0, 'days since 1999'))) or isinstance(l, type('')):
-                                if not isinstance(l, type('')):
+                            if isinstance(el, type(cdtime.comptime(1999))) or isinstance(
+                                    el, type(cdtime.reltime(0, 'days since 1999'))) or isinstance(el, type('')):
+                                if not isinstance(el, type('')):
                                     newaxvals.append(
-                                        l.torel(faxes[i].units).value)
+                                        el.torel(faxes[i].units).value)
                                 else:
                                     newaxvals.append(cdtime.s2r(
-                                        l, faxes[i].units).value)
+                                        el, faxes[i].units).value)
                             else:
-                                newaxvals.append(l)
+                                newaxvals.append(el)
                             if bounds is not None:
                                 bounds.append([ax[-1] - 1., ax[-1] + 1])
                         else:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,1 @@
-if [[ `uname` == "Linux" ]]; then
-    export LDSHARED="-shared -pthread"
-else
-    export LDSHARED="-bundle -undefined dynamic_lookup"
-fi
 $PYTHON -m pip install . --no-deps -vv


### PR DESCRIPTION
updated circleci workflow to run tests with libnetcdf nompi, mpich and openmpi variants. 
fixed flake8 (3.8.1) failures.
clean up recipe/build.sh
