### PR TITLE
Fix conda build env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,9 +65,7 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       # TODO 
-       # UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN"
-       UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN label=linatest"
+       UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN"
        make conda-upload workdir=$WORKDIR $UPLOAD_OPTIONS artifact_dir="$PWD/artifacts/*/"
 
 executors:
@@ -164,6 +162,6 @@ workflows:
          - upload:
               requires:
                  - test
-#              filters:
-#                 branches:
-#                    only: master
+              filters:
+                 branches:
+                    only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       make conda-rerender workdir=$WORKDIR branch=$CIRCLE_BRANCH
+       make conda-rerender conda_build_env=base workdir=$WORKDIR branch=$CIRCLE_BRANCH
 
   - &conda_build
     name: conda_build
@@ -38,7 +38,7 @@ aliases:
        conda activate base
        os=`uname`
        artifacts_dir="artifacts/artifacts.${os}.py_${PY_VER}"
-       make conda-build workdir=$WORKDIR artifact_dir=$artifacts_dir build_version=$PY_VER
+       make conda-build conda_build_env=base workdir=$WORKDIR artifact_dir=$PWD/$artifacts_dir build_version=$PY_VER
 
   - &setup_run_tests
     name: setup_run_tests
@@ -65,8 +65,10 @@ aliases:
        source $BASH_ENV
        source $WORKDIR/miniconda/etc/profile.d/conda.sh
        conda activate base
-       UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN"
-       make conda-upload workdir=$WORKDIR $UPLOAD_OPTIONS artifact_dir="artifacts/*/"
+       # TODO 
+       # UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN"
+       UPLOAD_OPTIONS="conda_upload_token=$CONDA_UPLOAD_TOKEN label=linatest"
+       make conda-upload workdir=$WORKDIR $UPLOAD_OPTIONS artifact_dir="$PWD/artifacts/*/"
 
 executors:
    linux:
@@ -162,6 +164,6 @@ workflows:
          - upload:
               requires:
                  - test
-              filters:
-                 branches:
-                    only: master
+#              filters:
+#                 branches:
+#                    only: master

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ build_script = conda-recipes/build_tools/conda_build.py
 test_pkgs = testsrunner
 last_stable ?= 8.2
 
-conda_test_env = test-$(pkg_name)
-conda_build_env = build-$(pkg_name)
+conda_test_env ?= test-$(pkg_name)
+conda_build_env ?= build-$(pkg_name)
 conda_dev_env = dev-$(pkg_name)
 
 branch ?= $(shell git rev-parse --abbrev-ref HEAD)
@@ -40,7 +40,7 @@ endif
 workdir := $(shell cat $(PWD)/.tempdir)
 endif
 
-artif_dir = $(workdir)/$(artifact_dir)
+artifact_dir ?= $(PWD)/artifacts
 
 ifneq ($(coverage),)
 coverage = -c tests/coverage.json --coverage-from-egg
@@ -51,7 +51,7 @@ conda_recipes_branch ?= master
 conda_base = $(patsubst %/bin/conda,%,$(conda))
 conda_activate = $(conda_base)/bin/activate
 
-conda_build_extra = --copy_conda_package $(artif_dir)/
+conda_build_extra = --copy_conda_package $(artifact_dir)/
 
 # Is this needed?
 # ifndef $(local_repo)
@@ -120,15 +120,15 @@ conda-rerender: setup-build ## Rerender conda recipe using conda-smithy
 		--conda_activate $(conda_activate)
 
 conda-build: ## Builds conda recipe
-	mkdir -p $(artif_dir)
+	mkdir -p $(artifact_dir)
 
 	python $(workdir)/$(build_script) -w $(workdir) -p $(pkg_name) --build_version $(build_version) \
 		--do_build --conda_env $(conda_build_env) --extra_channels $(extra_channels) \
 		--conda_activate $(conda_activate) $(conda_build_extra)
 
-conda-upload: ## Upload conda packages in artifcat directory
+conda-upload: ## Upload conda packages in artifact directory
 	source $(conda_activate) $(conda_build_env); \
-		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) --force $(artif_dir)/*.tar.bz2
+		anaconda -t $(conda_upload_token) upload -u $(user) -l $(label) --force $(artifact_dir)/*.tar.bz2
 
 conda-dump-env: ## Dumps conda environment
 	mkdir -p $(artifact_dir)


### PR DESCRIPTION
+ set conda_build_env and conda_test_env to a default value in Makefile if it is not passed in.
+ pass in 'conda_build_env=base' when doing 'make conda-rerender' and 'make conda-build' in .circleci/config.yml
